### PR TITLE
It turns out there is a bug in iOS that doesn't cleanup scenes properly....

### DIFF
--- a/PencilAdventure/PencilAdventure/GameOverScene.swift
+++ b/PencilAdventure/PencilAdventure/GameOverScene.swift
@@ -64,6 +64,7 @@ class GameOverScene: SKScene {
       if let buttonName = node.name {
         switch buttonName {
           case "okButton":
+			SKNode.cleanupScene(self)
             view.presentScene(LevelSelectScene(size: CGSize(width: view.frame.width, height: view.frame.height)))
             break
           default: break

--- a/PencilAdventure/PencilAdventure/GameScene.swift
+++ b/PencilAdventure/PencilAdventure/GameScene.swift
@@ -139,7 +139,7 @@ class GameScene : SKScene, SKPhysicsContactDelegate, GameOverProtocol {
         // Setup a timer for the update
         sketchAnimationTimer = NSTimer.scheduledTimerWithTimeInterval(1.0 / SketchAnimationFPS, target: self, selector: Selector("sketchAnimationTimer:"), userInfo: nil, repeats: true)
     }
-    
+	
     private func scaleToFillScreenWithAspect(srcSize: CGSize, targetSize: CGSize) -> CGFloat {
         // Find the dimension that has to grow the most
         let deltaWidth = abs(targetSize.width - srcSize.width)
@@ -423,6 +423,8 @@ class GameScene : SKScene, SKPhysicsContactDelegate, GameOverProtocol {
     }
     //TODO: need game end scene for logic here
     func gameEnd(didWin:Bool) {
+		SKNode.cleanupScene(self)
+		
         if (didWin) {
             self.view.presentScene(LevelFinishedScene())
         } else {

--- a/PencilAdventure/PencilAdventure/GameViewController.swift
+++ b/PencilAdventure/PencilAdventure/GameViewController.swift
@@ -17,8 +17,8 @@ class GameViewController: UIViewController {
 
     // Setup our SpriteKit view.
 		let view = self.view as SKView
-		view.showsFPS = true
-		view.showsNodeCount = true
+//		view.showsFPS = true
+//		view.showsNodeCount = true
 		view.ignoresSiblingOrder = true
 
     // Start the background music.

--- a/PencilAdventure/PencilAdventure/LevelFinishedScene.swift
+++ b/PencilAdventure/PencilAdventure/LevelFinishedScene.swift
@@ -64,6 +64,7 @@ class LevelFinishedScene: SKScene {
       if let buttonName = node.name {
         switch buttonName {
         case "backButton":
+		  SKNode.cleanupScene(self)
           view.presentScene(LevelSelectScene(size: CGSize(width: view.frame.width, height: view.frame.height)))
           break
         default: break

--- a/PencilAdventure/PencilAdventure/LevelSelectScene.swift
+++ b/PencilAdventure/PencilAdventure/LevelSelectScene.swift
@@ -107,6 +107,7 @@ class LevelSelectScene : SKScene {
         // If we're already loading a level, disallow
         // other levels being loaded.
         if isLoading {
+			NSLog("Avoiding interruptive load")
             return
         }
         isLoading = true
@@ -119,7 +120,7 @@ class LevelSelectScene : SKScene {
         SoundManager.restartBackgroundMusic()
         
         // Add our progress to the scene
-        addProgressLoaderNode()
+		addProgressLoaderNode()
         
         // Unarchive scene.
         work.append {
@@ -135,17 +136,22 @@ class LevelSelectScene : SKScene {
             for job in work {
                 done++
                 job()
-                self.progressLoader.setProgress(CGFloat(done) / CGFloat(work.count))
-                if done == work.count {
-                    // Notify the main thread that that we're ready!
-                    dispatch_async(dispatch_get_main_queue()) {
-                        self.scene.view.presentScene(scene!)
-                        self.isLoading = false
-                    }
-                }
+				self.progressLoader.setProgress(CGFloat(done) / CGFloat(work.count))
             }
+			
+			// Present our new scene
+			dispatch_async(dispatch_get_main_queue()) {
+				if let newScene = scene {
+					SKNode.cleanupScene(self)
+					self.view.presentScene(newScene)
+				}
+				else {
+					NSLog("The scene is nil!")
+				}
+				
+				self.isLoading = false
+			}
         }
-        
     }
 
     override func touchesBegan(touches: NSSet, withEvent event: UIEvent) {

--- a/PencilAdventure/PencilAdventure/SKNode+Extensions.swift
+++ b/PencilAdventure/PencilAdventure/SKNode+Extensions.swift
@@ -45,4 +45,11 @@ extension SKNode {
         xform = CGAffineTransformScale(xform, xScale, yScale)
         return xform
     }
+
+	class func cleanupScene(node: SKNode) {
+		for child in node.children as [SKNode] {
+			cleanupScene(child)
+		}
+		node.removeFromParent()
+	}
 }


### PR DESCRIPTION
... I find this hard to believe, but the solution to our crashes proves that this is an issue (or there is a scarier systemic problem at work here.)

Incidentally, during testing, I noticed another bug - as you played the game over and over without restarting, after about 15 times through the level, it would get slower and slower and use more and more memory. The frame rate would get down to about 7FPS (and even lower if I would keep testing) and the memory footprint would reach over a GB (!!). This fix solves this problem as well.

The fix is to cleanup the currently presented scene recursively before presenting the new scene.
