### PR TITLE
XCode 6.0 GM broke playgrounds targeted at OSX. Some of our playgrounds...

### DIFF
--- a/Playgrounds/Life Line Node.playground/contents.xcplayground
+++ b/Playgrounds/Life Line Node.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='3.0' sdk='macosx'>
+<playground version='3.0' sdk='iphonesimulator'>
     <sections>
         <documentation relative-path='fragment0.html'/>
         <code source-file-name='section-2.swift'/>

--- a/Playgrounds/Life Line Node.playground/section-4.swift
+++ b/Playgrounds/Life Line Node.playground/section-4.swift
@@ -9,11 +9,11 @@ extension SKScene {
     }
     
     func getSceneScaleX() -> CGFloat {
-        return frame.width / view.frame.width
+        return frame.width / view!.frame.width
     }
     
     func getSceneScaleY() -> CGFloat {
-        return frame.height / view.frame.height
+        return frame.height / view!.frame.height
     }
 }
 

--- a/Playgrounds/Life Line Node.playground/section-6.swift
+++ b/Playgrounds/Life Line Node.playground/section-6.swift
@@ -25,7 +25,7 @@ public class LifeLineNode: SKCropNode {
     
     private func subtractLifeLine() {
         lifeLine -= 0.01
-        maskNode.yScale = lifeLine
+        maskNode!.yScale = lifeLine
         if lifeLine > 0 {
             callbackAfter(0.1, subtractLifeLine)
         } else {
@@ -40,7 +40,7 @@ public class LifeLineNode: SKCropNode {
         } else {
             lifeLine += life
         }
-        maskNode.yScale = lifeLine
+        maskNode!.yScale = lifeLine
     }
     
 }

--- a/Playgrounds/Life Line Node.playground/section-8.swift
+++ b/Playgrounds/Life Line Node.playground/section-8.swift
@@ -1,4 +1,4 @@
-let sceneView = SKView(frame: NSRect(x: 0, y: 0, width: 850, height: 638))
+let sceneView = SKView(frame: CGRect(x: 0, y: 0, width: 850, height: 638))
 let scene = SKScene(fileNamed: "GameScene")
 scene.scaleMode = .AspectFill
 sceneView.presentScene(scene)

--- a/Playgrounds/Life Line Node.playground/timeline.xctimeline
+++ b/Playgrounds/Life Line Node.playground/timeline.xctimeline
@@ -2,5 +2,11 @@
 <Timeline
    version = "3.0">
    <TimelineItems>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=2021&amp;EndingColumnNumber=10&amp;EndingLineNumber=73&amp;StartingColumnNumber=1&amp;StartingLineNumber=73&amp;Timestamp=432602314.546661">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=31&amp;CharacterRangeLoc=445&amp;EndingColumnNumber=47&amp;EndingLineNumber=15&amp;StartingColumnNumber=16&amp;StartingLineNumber=15&amp;Timestamp=432602314.546661">
+      </LoggerValueHistoryTimelineItem>
    </TimelineItems>
 </Timeline>

--- a/Playgrounds/Rain Particle Effect.playground/contents.xcplayground
+++ b/Playgrounds/Rain Particle Effect.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='3.0' sdk='macosx'>
+<playground version='3.0' sdk='iphonesimulator'>
     <sections>
         <documentation relative-path='fragment0.html'/>
         <code source-file-name='section-2.swift'/>

--- a/Playgrounds/Rain Particle Effect.playground/section-4.swift
+++ b/Playgrounds/Rain Particle Effect.playground/section-4.swift
@@ -1,4 +1,4 @@
-let sceneView = SKView(frame: NSRect(x: 0, y: 0, width: 850, height: 638))
+let sceneView = SKView(frame: CGRect(x: 0, y: 0, width: 850, height: 638))
 let scene = SKScene(fileNamed: "GameScene")
 scene.scaleMode = .AspectFill
 sceneView.presentScene(scene)

--- a/Playgrounds/Rain Particle Effect.playground/section-8.swift
+++ b/Playgrounds/Rain Particle Effect.playground/section-8.swift
@@ -1,5 +1,5 @@
 rainParticle.particleBirthRate = 10
 rainParticle.emissionAngle = CGFloat(-100 * M_PI / 180)
 scene.addChild(rainParticle)
-scene.backgroundColor = NSColor.blackColor()
+scene.backgroundColor = UIColor.blackColor()
 


### PR DESCRIPTION
... were targetted at 'macosx' and some were targetted (correctly) at 'iphonesimulator'. The 'macosx' targets were fixed and the playgrounds updated to conform to the latest XCode changes.
